### PR TITLE
Fixed Interact/Beosonic bug where "Select Listening Mode" was applied

### DIFF
--- a/Beocreate2/beo-extensions/beosonic/index.js
+++ b/Beocreate2/beo-extensions/beosonic/index.js
@@ -524,9 +524,9 @@ interact = {
 					}
 				}
 			} else {
-				if (compactPresetList[triggerResult]) {
-					applyBeosonicPreset(triggerResult);
-					return compactPresetList[triggerResult].presetName;
+				if (compactPresetList[interactData.preset]) {
+					applyBeosonicPreset(interactData.preset);
+					return compactPresetList[interactData.preset].presetName;
 				} else {
 					return undefined;
 				}


### PR DESCRIPTION
The "Select Listening Mode" interact action did not work in combination with the Source Started trigger, due to 'triggerResult' being passed (which normally contains an index, and is normally handled in the branch earlier), instead of 'interactData.preset' (which contains the preset name).

See https://github.com/hifiberry/hifiberry-os/issues/454