### PR TITLE
Display scroll invitation for play queue on mobile

### DIFF
--- a/Beocreate2/beo-extensions/now-playing/now-playing.css
+++ b/Beocreate2/beo-extensions/now-playing/now-playing.css
@@ -654,3 +654,11 @@
 	
 	
 }
+
+@media only screen and (max-aspect-ratio: 10/19) {
+	
+	#now-playing-info-area .scroll-invitation {
+		display: block;
+	}
+	
+}


### PR DESCRIPTION
The scroll invitation arrow was never displaying on mobile even when there was space for it. This change will show the arrow based on the aspect ratio of the viewport.