### PR TITLE
Automatically Play Inserted CDs

### DIFF
--- a/Beocreate2/beo-extensions/cd-autoplay/cd-autoplay-client.js
+++ b/Beocreate2/beo-extensions/cd-autoplay/cd-autoplay-client.js
@@ -1,0 +1,34 @@
+var cd_autoplay = (function() {
+
+	var cdAutoplayEnabled = false;
+
+	$(document).on("cd-autplay", function(_, data) {
+		if (data.header == "cdAutoplaySettings") {
+			if (data.content.cdAutoplayEnabled) {
+				cdAutoplayEnabled = true;
+				$("#cd-autoplay-enabled-toggle").addClass("on");
+			} else {
+				cdAutoplayEnabled = false;
+				$("#cd-autoplay-enabled-toggle").removeClass("on");
+			}
+
+			beo.notify(false, "cd-autoplay");
+		}
+	});
+
+
+	function toggleEnabled() {
+		enabled = (!cdAutoplayEnabled) ? true : false;
+		if (enabled) {
+			beo.notify({ title: "Turning automatic CD playback on...", icon: "attention", timeout: false, id: "cd-autoplay" });
+		} else {
+			beo.notify({ title: "Turning automatic CD playback off...", icon: "attention", timeout: false, id: "cd-autoplay" });
+		}
+		beo.send({ target: "cd-autoplay", header: "cdAutoplayEnabled", content: { enabled: enabled } });
+	}
+
+	return {
+		toggleEnabled: toggleEnabled,
+	};
+
+})();

--- a/Beocreate2/beo-extensions/cd-autoplay/cd-autoplay-client.js
+++ b/Beocreate2/beo-extensions/cd-autoplay/cd-autoplay-client.js
@@ -1,8 +1,7 @@
 var cd_autoplay = (function() {
-
 	var cdAutoplayEnabled = false;
 
-	$(document).on("cd-autplay", function(_, data) {
+	$(document).on("cd-autoplay", function(event, data) {
 		if (data.header == "cdAutoplaySettings") {
 			if (data.content.cdAutoplayEnabled) {
 				cdAutoplayEnabled = true;
@@ -15,7 +14,6 @@ var cd_autoplay = (function() {
 			beo.notify(false, "cd-autoplay");
 		}
 	});
-
 
 	function toggleEnabled() {
 		enabled = (!cdAutoplayEnabled) ? true : false;
@@ -30,5 +28,4 @@ var cd_autoplay = (function() {
 	return {
 		toggleEnabled: toggleEnabled,
 	};
-
 })();

--- a/Beocreate2/beo-extensions/cd-autoplay/index.js
+++ b/Beocreate2/beo-extensions/cd-autoplay/index.js
@@ -1,0 +1,124 @@
+/*Copyright 2018 Bang & Olufsen A/S
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.*/
+
+var exec = require("child_process").exec;
+
+var debug = beo.debug;
+var version = require("./package.json").version;
+
+var settings = {
+	cdAutoplayEnabled: false,
+}
+
+var sources = null;
+
+var cdAutoplayEnabled = false;
+
+beo.bus.on('general', function(event) {
+
+	if (event.header == "startup") {
+
+		if (beo.extensions.sources &&
+			beo.extensions.sources.setSourceOptions &&
+			beo.extensions.sources.sourceDeactivated) {
+			sources = beo.extensions.sources;
+		}
+
+		if (sources) {
+			getCdAutoplayStatus(function(enabled) {
+				sources.setSourceOptions("cd-autoplay", {
+					enabled: enabled,
+					transportControls: true,
+					usesHifiberryControl: true,
+					aka: "cdAutoplay"
+				});
+			});
+		}
+	}
+
+	if (event.header == "activatedExtension") {
+		if (event.content.extension == "cd-autoplay") {
+			beo.bus.emit("ui", { target: "cd-autoplay", header: "cdAutoplaySettings", content: settings });
+		}
+	}
+});
+
+beo.bus.on('product-information', function(event) {
+	if (event.header == "systemNameChanged") {
+		// do nothing, let the reconfigure-players script handle the system name change
+	}
+});
+
+beo.bus.on('cd-autoplay', function(event) {
+	if (event.header == "cdAutoplayEnabled") {
+		if (event.content.enabled != undefined) {
+			setCdAutoplayStatus(event.content.enabled, function(newStatus, error) {
+				settings.cdAutoplayEnabled = newStatus
+				beo.bus.emit("ui", { target: "cd-autoplay", header: "cdAutoplaySettings", content: settings });
+				if (sources) sources.setSourceOptions("cd-autoplay", { enabled: newStatus });
+				if (newStatus == false) {
+					if (sources) sources.sourceDeactivated("cd-autoplay");
+				}
+				if (error) {
+					beo.bus.emit("ui", { target: "cd-autoplay", header: "errorTogglingCdAutoplay", content: {} });
+				}
+			});
+		}
+	}
+});
+
+function getCdAutoplayStatus(callback) {
+	exec("systemctl is-enabled --quiet mpd-cd-autoplay.service").on('exit', function(code) {
+		if (code == 0) {
+			cdAutoplayEnabled = true;
+			callback(true);
+		} else {
+			cdAutoplayEnabled = false;
+			callback(false);
+		}
+	});
+}
+
+function setCdAutoplayStatus(enabled, callback) {
+	if (enabled) {
+		exec("systemctl unmask mpd-cd-autoplay.service").on('exit', function(code) {
+			if (code == 0) {
+				cdAutoplayEnabled = true;
+				if (debug) console.log("cd-autoplay enabled.");
+				callback(true);
+			} else {
+				cdAutoplayEnabled = false;
+				callback(false, true);
+			}
+		});
+	} else {
+		exec("systemctl mask mpd-cd-autoplay.service").on('exit', function(code) {
+			cdAutoplayEnabled = false;
+			if (code == 0) {
+				callback(false);
+				if (debug) console.log("cd-autoplay disabled.");
+			} else {
+				callback(false, true);
+			}
+		});
+	}
+}
+
+module.exports = {
+	version: version,
+	isEnabled: getCdAutoplayStatus
+};

--- a/Beocreate2/beo-extensions/cd-autoplay/index.js
+++ b/Beocreate2/beo-extensions/cd-autoplay/index.js
@@ -21,17 +21,13 @@ var debug = beo.debug;
 var version = require("./package.json").version;
 
 var settings = {
-	cdAutoplayEnabled: false,
-}
+	cdAutoplayEnabled: false
+};
 
 var sources = null;
 
-var cdAutoplayEnabled = false;
-
 beo.bus.on('general', function(event) {
-
 	if (event.header == "startup") {
-
 		if (beo.extensions.sources &&
 			beo.extensions.sources.setSourceOptions &&
 			beo.extensions.sources.sourceDeactivated) {
@@ -44,7 +40,7 @@ beo.bus.on('general', function(event) {
 					enabled: enabled,
 					transportControls: true,
 					usesHifiberryControl: true,
-					aka: "cdAutoplay"
+					aka: "mpd-cd-autoplay"
 				});
 			});
 		}
@@ -67,7 +63,6 @@ beo.bus.on('cd-autoplay', function(event) {
 	if (event.header == "cdAutoplayEnabled") {
 		if (event.content.enabled != undefined) {
 			setCdAutoplayStatus(event.content.enabled, function(newStatus, error) {
-				settings.cdAutoplayEnabled = newStatus
 				beo.bus.emit("ui", { target: "cd-autoplay", header: "cdAutoplaySettings", content: settings });
 				if (sources) sources.setSourceOptions("cd-autoplay", { enabled: newStatus });
 				if (newStatus == false) {
@@ -84,10 +79,10 @@ beo.bus.on('cd-autoplay', function(event) {
 function getCdAutoplayStatus(callback) {
 	exec("systemctl is-enabled --quiet mpd-cd-autoplay.service").on('exit', function(code) {
 		if (code == 0) {
-			cdAutoplayEnabled = true;
+			settings.cdAutoplayEnabled = true;
 			callback(true);
 		} else {
-			cdAutoplayEnabled = false;
+			settings.cdAutoplayEnabled = false;
 			callback(false);
 		}
 	});
@@ -97,17 +92,17 @@ function setCdAutoplayStatus(enabled, callback) {
 	if (enabled) {
 		exec("systemctl unmask mpd-cd-autoplay.service").on('exit', function(code) {
 			if (code == 0) {
-				cdAutoplayEnabled = true;
+				settings.cdAutoplayEnabled = true;
 				if (debug) console.log("cd-autoplay enabled.");
 				callback(true);
 			} else {
-				cdAutoplayEnabled = false;
+				settings.cdAutoplayEnabled = false;
 				callback(false, true);
 			}
 		});
 	} else {
 		exec("systemctl mask mpd-cd-autoplay.service").on('exit', function(code) {
-			cdAutoplayEnabled = false;
+			settings.cdAutoplayEnabled = false;
 			if (code == 0) {
 				callback(false);
 				if (debug) console.log("cd-autoplay disabled.");

--- a/Beocreate2/beo-extensions/cd-autoplay/menu.html
+++ b/Beocreate2/beo-extensions/cd-autoplay/menu.html
@@ -12,7 +12,7 @@
 				<div class="menu-toggle"></div>
 			</div>
 			<p>Automatically play CDs when they are inserted.</p>
-			<p>Requires a CD compatible drive to be attached to the system.</p>
+			<p>Requires a CD compatible drive to be attached to the system. CD metadata is sourced from the <a href="https://musicbrainz.org" target="_blank">MusicBrainz</a> database.</p>
 			<p class="experiment">This is an experimental feature.</p>
 		</div>
 	</div>

--- a/Beocreate2/beo-extensions/cd-autoplay/menu.html
+++ b/Beocreate2/beo-extensions/cd-autoplay/menu.html
@@ -1,0 +1,21 @@
+<div class="menu-screen source" id="cd-autoplay" data-icon="cd.svg" data-menu-title="Automatically Play CDs">
+	
+	<header>
+		<div class="back-button master"></div>
+		<h1>Automatically Play CDs</h1>
+	</header>
+	
+	<div class="scroll-area">
+		<div class="menu-content">
+			<div class="menu-item toggle" id="cd-autoplay-enabled-toggle" onclick="cd_autoplay.toggleEnabled();">
+				<div class="menu-label">On</div>
+				<div class="menu-toggle"></div>
+			</div>
+			<p>Automatically play CDs when they are inserted.</p>
+			<p>Requires a CD compatible drive to be attached to the system.</p>
+			<p class="experiment">This is an experimental feature.</p>
+		</div>
+	</div>
+</div>
+
+<script type="text/javascript" charset="utf-8" src="€/cd-autoplay-client.js"></script>

--- a/Beocreate2/beo-extensions/cd-autoplay/menu.html
+++ b/Beocreate2/beo-extensions/cd-autoplay/menu.html
@@ -1,8 +1,8 @@
-<div class="menu-screen source" id="cd-autoplay" data-icon="cd.svg" data-menu-title="Automatically Play CDs">
+<div class="menu-screen source" id="cd-autoplay" data-icon="cd.svg" data-menu-title="Compact Disc">
 	
 	<header>
 		<div class="back-button master"></div>
-		<h1>Automatically Play CDs</h1>
+		<h1>Compact Disc</h1>
 	</header>
 	
 	<div class="scroll-area">

--- a/Beocreate2/beo-extensions/cd-autoplay/package.json
+++ b/Beocreate2/beo-extensions/cd-autoplay/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@beocreate/cd-autoplay",
+  "version": "0.1.0",
+  "description": "Controls for Automatic CD playback via MPD",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bang-olufsen/create.git"
+  },
+  "keywords": [
+    "beocreate",
+    "mpd",
+    "CD",
+    "compact disc"
+  ],
+  "author": "Bang & Olufsen",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bang-olufsen/create/issues"
+  },
+  "homepage": "https://github.com/bang-olufsen/create#readme",
+  "dependencies": {}
+}

--- a/Beocreate2/beo-extensions/cd-autoplay/symbols-black/cd.svg
+++ b/Beocreate2/beo-extensions/cd-autoplay/symbols-black/cd.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="23pt"
+   height="23pt"
+   viewBox="0 0 30.666667 30.666667"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <ellipse
+       style="fill:none;stroke:#000000;stroke-width:1.33333;stroke-dasharray:none;stroke-opacity:1"
+       id="path1"
+       cx="15.333333"
+       cy="15.333333"
+       rx="13.333336"
+       ry="13.333334" />
+    <path
+       id="path1-2"
+       style="fill:none;stroke:#000000;stroke-width:1.33333;stroke-linecap:round"
+       d="m 24.000001,15.333333 c 0,4.786468 -3.880199,8.666666 -8.666668,8.666666" />
+    <path
+       id="path1-2-7"
+       style="fill:none;stroke:#000000;stroke-width:1.33333;stroke-linecap:round"
+       transform="scale(-1)"
+       d="m -6.6666651,-15.333333 c 0,4.786467 -3.8801989,8.666666 -8.6666679,8.666666" />
+    <ellipse
+       style="fill:none;stroke:#000000;stroke-width:1.33333;stroke-dasharray:none;stroke-opacity:1"
+       id="path1-5"
+       cx="15.333336"
+       cy="15.333332"
+       rx="2.6666684"
+       ry="2.6666682" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
To complement hifiberry/hifiberry-os#501, this PR adds the user interface to toggle automatic CD playback.

## Screenshots
### Vertical
#### Light
<img src="https://github.com/hifiberry/create/assets/35574350/09db1918-a801-4746-bb77-cc5e4db0c1b3" width=25%>
<img src="https://github.com/hifiberry/create/assets/35574350/fd308ab4-48fe-4241-9d49-13fb3288c93a" width=25%>

#### Dark
<img src="https://github.com/hifiberry/create/assets/35574350/e080c35f-a8ca-4651-99bc-4d98148da262" width=25%>

### Horizontal
![Screen Shot 2024-05-10 at 14 40 33](https://github.com/hifiberry/create/assets/35574350/830a7c64-9d78-4346-87e7-5486836d76a4)


## Change Log
* Add a new source called "Compact Disc".
* Toggle masking the `mpd-cd-autoplay` service from hifiberry/hifiberry-os#501 depending on the toggle status.