### PR TITLE
Fix SMB passwords containing special characters being unusable

### DIFF
--- a/Beocreate2/beo-extensions/mpd/index.js
+++ b/Beocreate2/beo-extensions/mpd/index.js
@@ -1353,7 +1353,8 @@ async function getNASShares(details) {
 			} else {
 				address = details.server.addresses[0];
 			}
-			sharesRaw = await execPromise("smbclient -N -L "+address+" --user="+details.username+"%"+details.password+" -g | grep 'Disk|'");
+			const escapedPassword = details.password.replaceAll("'", "'\\''");
+			sharesRaw = await execPromise("smbclient -N -L "+address+" --user="+details.username+" --password='"+escapedPassword+"' -g | grep 'Disk|'");
 			sharesRaw = sharesRaw.stdout.trim().split("\n");
 			for (s in sharesRaw) {
 				shareList.push(sharesRaw[s].split("|")[1]);


### PR DESCRIPTION
When an SMB password contained shell control characters like $! or the % sign used to separate the username from the password with the --user=user%password flag, the called smbclient command would crash and the web interface would tell the user that no shares could be found.

We now specify the password with the --password flag instead of the --user flag and enclose it in single quotes to allow all characters. Only the literal single quote has to be escaped to not trip up the shell executing the command.